### PR TITLE
Add secure storage setup tool with encrypted Room and files

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,13 +803,15 @@ Implements HIPAA-compliant security measures.
 ```
 
 ##### 18. `setup_secure_storage` - Secure Data Storage
-Configures encrypted storage for sensitive data.
+Configures encrypted storage for sensitive data using Room with SQLCipher or
+EncryptedFile with keys stored in the Android Keystore. The tool also scans
+your codebase and suggests refactors for insecure storage patterns.
 
 ```json
 {
   "name": "setup_secure_storage",
   "arguments": {
-    "storage_type": "room_encrypted",
+    "storage_type": "room",
     "package_name": "com.example.app",
     "data_classification": "restricted",
     "key_management": "android_keystore"
@@ -1312,7 +1314,7 @@ All tools provide comprehensive error information:
 {
   "name": "setup_secure_storage",
   "arguments": {
-    "storage_type": "room_encrypted",
+    "storage_type": "room",
     "package_name": "com.example.app",
     "data_classification": "restricted"
   }
@@ -1738,7 +1740,7 @@ openssl s_client -connect api.example.com:443
 {
   "name": "setup_secure_storage", 
   "arguments": {
-    "storage_type": "room_encrypted",
+    "storage_type": "room",
     "data_classification": "restricted"
   }
 }

--- a/kotlin_mcp_server.py
+++ b/kotlin_mcp_server.py
@@ -503,13 +503,20 @@ class KotlinMCPServerV2:
             },
             {
                 "name": "setup_secure_storage",
-                "description": "Setup secure storage with encryption and access controls",
+                "description": "Setup secure storage using Room encryption or EncryptedFile with Keystore-managed keys",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "storage_type": {
                             "type": "string",
-                            "enum": ["shared_preferences", "room", "keystore", "file"],
+                            "enum": [
+                                "shared_preferences",
+                                "encrypted_sharedprefs",
+                                "room",
+                                "encrypted_file",
+                                "keystore",
+                                "file",
+                            ],
                             "description": "Type of storage to secure",
                         },
                         "encryption_level": {

--- a/mcp_baseline.json
+++ b/mcp_baseline.json
@@ -792,7 +792,7 @@
         },
         {
           "name": "setup_secure_storage",
-          "description": "Setup secure storage with encryption and access controls",
+          "description": "Setup secure storage using Room encryption or EncryptedFile with Keystore-managed keys",
           "has_schema": true,
           "required_params": [
             "storage_type",
@@ -1198,7 +1198,7 @@
         },
         {
           "name": "setup_secure_storage",
-          "description": "Setup secure storage with encryption and access controls",
+          "description": "Setup secure storage using Room encryption or EncryptedFile with Keystore-managed keys",
           "has_schema": true,
           "required_params": [
             "storage_type",

--- a/tools/intelligent_tool_manager.py
+++ b/tools/intelligent_tool_manager.py
@@ -28,6 +28,7 @@ from tools.intelligent_ui_tools import (
     IntelligentComposeComponentTool,
     IntelligentMVVMArchitectureTool,
 )
+from tools.security_tools import SetupSecureStorageTool
 
 
 class SimpleToolProxy(IntelligentToolBase):
@@ -79,6 +80,7 @@ class IntelligentMCPToolManager:
             "generate_docs": IntelligentDocumentationTool(*base_args),
             "create_compose_component": IntelligentComposeComponentTool(*base_args),
             "setup_mvvm_architecture": IntelligentMVVMArchitectureTool(*base_args),
+            "setup_secure_storage": SetupSecureStorageTool(*base_args),
         }
 
         # Tools that need proxy implementations
@@ -104,7 +106,6 @@ class IntelligentMCPToolManager:
             "encrypt_sensitive_data",
             "implement_gdpr_compliance",
             "implement_hipaa_compliance",
-            "setup_secure_storage",
             # AI/ML Tools
             "query_llm",
             "analyze_code_with_ai",

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Security tools for secure storage operations.
+
+This module provides implementations for secure storage setup using either
+Room with SQLCipher encryption or EncryptedFile, with keys managed via the
+Android Keystore. It also scans Kotlin source files to suggest refactors for
+insecure storage usages like plain SharedPreferences or unencrypted files.
+"""
+
+from typing import Any, Dict, List
+
+from tools.intelligent_base import IntelligentToolBase, IntelligentToolContext
+
+
+class SetupSecureStorageTool(IntelligentToolBase):
+    """Configure encrypted storage and suggest refactors for insecure usages."""
+
+    async def _execute_core_functionality(
+        self, context: IntelligentToolContext, arguments: Dict[str, Any]
+    ) -> Any:
+        storage_type = arguments.get("storage_type", "room").lower()
+
+        setup_code = self._generate_setup_code(storage_type)
+        refactor_suggestions = await self._find_insecure_storage_usages()
+
+        return {
+            "storage_type": storage_type,
+            "setup_code": setup_code,
+            "refactor_suggestions": refactor_suggestions,
+        }
+
+    def _generate_setup_code(self, storage_type: str) -> str:
+        """Return Kotlin snippet for requested secure storage type."""
+        if storage_type == "room":
+            return (
+                """// Room database with SQLCipher encryption and Keystore-managed key
+val keyAlias = \"room_db_key\"
+val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+    keyAlias,
+    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+ .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+ .setKeySize(256)
+ .build()
+
+val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, \"AndroidKeyStore\")
+keyGenerator.init(keyGenParameterSpec)
+val secretKey = keyGenerator.generateKey()
+val passphrase = SQLiteDatabase.getBytes(secretKey.encoded)
+val factory = SupportFactory(passphrase)
+
+val db = Room.databaseBuilder(context, AppDatabase::class.java, \"secure.db\")
+    .openHelperFactory(factory)
+    .build()
+"""
+            )
+        if storage_type == "encrypted_file":
+            return (
+                """// EncryptedFile with key stored in Android Keystore
+val masterKey = MasterKey.Builder(context)
+    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+    .build()
+
+val file = File(context.filesDir, \"secret.txt\")
+val encryptedFile = EncryptedFile.Builder(
+    context,
+    file,
+    masterKey,
+    EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+).build()
+
+encryptedFile.openFileOutput().bufferedWriter().use {
+    it.write(\"Sensitive data\")
+}
+"""
+            )
+        if storage_type == "encrypted_sharedprefs" or storage_type == "shared_preferences":
+            return (
+                """// EncryptedSharedPreferences backed by Android Keystore
+val masterKey = MasterKey.Builder(context)
+    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+    .build()
+
+val prefs = EncryptedSharedPreferences.create(
+    context,
+    \"secure_prefs\",
+    masterKey,
+    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+)
+"""
+            )
+        if storage_type == "keystore":
+            return (
+                """// Generate and retrieve keys directly from Android Keystore
+val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+    "app_master_key",
+    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+ .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+ .setKeySize(256)
+ .build()
+
+val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+keyGenerator.init(keyGenParameterSpec)
+val secretKey = keyGenerator.generateKey()
+"""
+            )
+        return "// Unsupported storage type"
+
+    async def _find_insecure_storage_usages(self) -> List[Dict[str, str]]:
+        """Scan project for insecure storage patterns and suggest refactors."""
+        patterns = {
+            "SharedPreferences": "Replace with EncryptedSharedPreferences or secure storage.",
+            "openFileOutput": "Use EncryptedFile with a Keystore-managed key.",
+            "File(": "Use EncryptedFile or Room with SQLCipher.",
+        }
+        suggestions: List[Dict[str, str]] = []
+        for path in self.project_path.rglob("*.kt"):
+            try:
+                content = path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            for pattern, recommendation in patterns.items():
+                if pattern in content:
+                    suggestions.append(
+                        {
+                            "file": str(path),
+                            "issue": f"Uses {pattern}",
+                            "recommendation": recommendation,
+                        }
+                    )
+        return suggestions


### PR DESCRIPTION
## Summary
- implement `SetupSecureStorageTool` for Room encryption and EncryptedFile using Android Keystore
- register secure storage tool in manager and update tool schema
- document secure storage capabilities and descriptions

## Testing
- `pytest tests/utils/test_security.py::TestSecurityUtils::test_setup_secure_storage -q`
- `pytest tests/utils/test_security.py::TestSecurityUtils::test_security_tools_variations -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1af2c3e50832d9ae3d8d4259662ae