### PR TITLE
feat: add intelligent layout file tool

### DIFF
--- a/tools/intelligent_tool_manager.py
+++ b/tools/intelligent_tool_manager.py
@@ -26,6 +26,7 @@ from tools.intelligent_code_tools_simple import (
 )
 from tools.intelligent_ui_tools import (
     IntelligentComposeComponentTool,
+    IntelligentLayoutFileTool,
     IntelligentMVVMArchitectureTool,
 )
 
@@ -78,6 +79,7 @@ class IntelligentMCPToolManager:
             "run_lint": IntelligentLintTool(*base_args),
             "generate_docs": IntelligentDocumentationTool(*base_args),
             "create_compose_component": IntelligentComposeComponentTool(*base_args),
+            "create_layout_file": IntelligentLayoutFileTool(*base_args),
             "setup_mvvm_architecture": IntelligentMVVMArchitectureTool(*base_args),
         }
 
@@ -89,7 +91,6 @@ class IntelligentMCPToolManager:
             "analyze_project",
             # File Creation Tools
             "create_kotlin_file",
-            "create_layout_file",
             # Project Analysis Tools
             "analyze_and_refactor_project",
             "optimize_build_performance",


### PR DESCRIPTION
## Summary
- add `IntelligentLayoutFileTool` for scaffolding XML layouts, validating attributes, and LSP-based reference checks
- integrate layout tool into manager so `create_layout_file` uses intelligent implementation

## Testing
- `pytest tests/test_ui_layout_tools.py -q`
- `pytest tests/test_server_core.py::TestKotlinMCPServerCore::test_all_27_tools_systematically -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1af0ac054832dbd8c69f59943e564