### PR TITLE
Handle missing Kotlin generator gracefully

### DIFF
--- a/kotlin_mcp_server.py
+++ b/kotlin_mcp_server.py
@@ -1071,7 +1071,16 @@ Please generate the complete Room database setup with all components.
         await self.send_progress(operation_id, 25, "Validating parameters")
 
         if not self.kotlin_generator:
-            raise RuntimeError("Kotlin generator not initialized")
+            await self.send_progress(operation_id, 100, "Kotlin generator not initialized")
+            return {
+                "success": False,
+                "error": "Kotlin generator not initialized",
+                "message": (
+                    "Start the server with a valid project path (e.g., "
+                    "python kotlin_mcp_server.py /path/to/project) or call "
+                    "set_project_path() before invoking this tool."
+                ),
+            }
 
         await self.send_progress(operation_id, 50, "Generating Kotlin code")
 

--- a/tests/test_mcp_server_v2_enhanced.py
+++ b/tests/test_mcp_server_v2_enhanced.py
@@ -187,6 +187,25 @@ class TestKotlinMCPServerV2(unittest.TestCase):
         progress_values = [msg[1] for msg in progress_messages]
         self.assertIn(0, progress_values)  # Should start at 0
 
+    async def test_create_kotlin_file_without_generator(self):
+        """Gracefully handle missing Kotlin generator."""
+
+        args = CreateKotlinFileRequest(
+            file_path="Missing.kt",
+            package_name="com.test",
+            class_name="Missing",
+            class_type="class",
+        )
+
+        # Simulate missing generator
+        self.server.kotlin_generator = None
+
+        result = await self.server.call_create_kotlin_file(args, "op-missing")
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Kotlin generator not initialized")
+        self.assertIn("Start the server", result["message"])
+
     async def test_mcp_request_response_cycle(self):
         """Test complete MCP request/response cycle."""
         # Test initialize


### PR DESCRIPTION
## Summary
- return structured error when Kotlin generator is uninitialized and suggest initialization steps
- add unit test for missing Kotlin generator scenario

## Testing
- `pytest tests/test_mcp_server_v2_enhanced.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1a9131ed8832d9e9596d628850655