### PR TITLE
Return structured failure when analysis tools missing

### DIFF
--- a/kotlin_mcp_server.py
+++ b/kotlin_mcp_server.py
@@ -1161,9 +1161,20 @@ Please generate the complete Room database setup with all components.
         """Execute analyze_project tool."""
 
         await self.send_progress(operation_id, 30, "Starting project analysis")
-
         if not self.project_analysis:
-            raise RuntimeError("Project analysis tools not initialized - project path required")
+            await self.send_progress(
+                operation_id,
+                100,
+                "Project analysis tools missing - initialization required",
+            )
+            return {
+                "success": False,
+                "analysis_type": args.analysis_type,
+                "message": (
+                    "Project analysis tools not initialized. Provide a project path "
+                    "or run the initialization step before analyzing."
+                ),
+            }
 
         await self.send_progress(operation_id, 60, f"Performing {args.analysis_type} analysis")
 

--- a/tests/test_mcp_server_v2_enhanced.py
+++ b/tests/test_mcp_server_v2_enhanced.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from kotlin_mcp_server import (
     CreateKotlinFileRequest,
     GradleBuildRequest,
+    ProjectAnalysisRequest,
     KotlinMCPServerV2,
 )
 
@@ -162,6 +163,14 @@ class TestKotlinMCPServerV2(unittest.TestCase):
         response = await self.server.handle_request(request_data)
         self.assertIn("error", response)
         self.assertEqual(response["error"]["code"], -32602)
+
+    async def test_analyze_project_without_initialization(self):
+        """call_analyze_project should return structured failure when uninitialized."""
+        server = KotlinMCPServerV2()
+        args = ProjectAnalysisRequest(analysis_type="structure")
+        result = await server.call_analyze_project(args, "op-test")
+        self.assertFalse(result["success"])
+        self.assertIn("project path", result["message"].lower())
 
     async def test_progress_tracking(self):
         """Test progress tracking functionality."""


### PR DESCRIPTION
## Summary
- handle analyze_project requests without initialization by returning a structured failure message guiding users to set a project path or initialize the server
- cover missing-project-path scenario with a unit test

## Testing
- `pytest tests/test_mcp_server_v2_enhanced.py::TestKotlinMCPServerV2::test_analyze_project_without_initialization -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1a9116f58832da05b45e5aaa23543