### PR TITLE
Handle missing project path in Gradle build tool

### DIFF
--- a/kotlin_mcp_server.py
+++ b/kotlin_mcp_server.py
@@ -1138,7 +1138,13 @@ Please generate the complete Room database setup with all components.
         await self.send_progress(operation_id, 20, "Preparing Gradle build")
 
         if not self.gradle_tools:
-            raise RuntimeError("Gradle tools not initialized - project path required")
+            return {
+                "success": False,
+                "error": (
+                    "Gradle tools not initialized - project path required. "
+                    "Start the server with --project-path or run the initialization command."
+                ),
+            }
 
         await self.send_progress(operation_id, 40, f"Running Gradle task: {args.task}")
 

--- a/tests/tools/test_gradle_tools.py
+++ b/tests/tools/test_gradle_tools.py
@@ -5,6 +5,7 @@ Tests all Gradle-related functionality
 """
 
 import tempfile
+import json
 
 import pytest
 
@@ -72,3 +73,17 @@ class TestGradleTools:
             result = await server.handle_call_tool(tool_name, args)
             assert "content" in result
             assert isinstance(result["content"], list)
+
+    @pytest.mark.asyncio
+    async def test_gradle_build_requires_project_path(self) -> None:
+        """Ensure structured error when project path is missing"""
+        server = KotlinMCPServer("test-server")
+        result = await server.handle_call_tool("gradle_build", {"task": "build"})
+
+        assert "content" in result
+        assert isinstance(result["content"], list)
+
+        response = json.loads(result["content"][0]["text"])
+        assert response["success"] is False
+        assert "project path required" in response["error"]
+        assert "--project-path" in response["error"]


### PR DESCRIPTION
## Summary
- return structured failure result when Gradle tools aren't initialized
- advise starting server with --project-path or running initialization
- test structured error response when project path missing

## Testing
- `pytest tests/tools/test_gradle_tools.py::TestGradleTools::test_gradle_build_requires_project_path -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a90fbbd8832da0283ed0159ba190